### PR TITLE
Build streamlit dashboard

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,0 +1,14 @@
+import streamlit as st
+import pandas as pd
+st.title("Share of Voice Dashboard")
+#below is mock data
+df = pd.DataFrame(
+    {
+        "Brand": ["Nike", "Adidas", "Puma", "Under Armour"],
+        "Share of Voice (%)": [42, 30, 18, 10],
+    }
+)
+st.subheader("Table")
+st.dataframe(df)
+st.subheader("Bar Chart")
+st.bar_chart(df.set_index("Brand"))

--- a/src/tracking/issue_2.py
+++ b/src/tracking/issue_2.py
@@ -1,0 +1,14 @@
+import streamlit as st
+import pandas as pd
+st.title("Share of Voice Dashboard")
+#below is mock data
+df = pd.DataFrame(
+    {
+        "Brand": ["Nike", "Adidas", "Puma", "Under Armour"],
+        "Share of Voice (%)": [42, 30, 18, 10],
+    }
+)
+st.subheader("Table")
+st.dataframe(df)
+st.subheader("Bar Chart")
+st.bar_chart(df.set_index("Brand"))

--- a/src/tracking/perplexity_client.py
+++ b/src/tracking/perplexity_client.py
@@ -24,7 +24,12 @@ def query_perplexity(prompt: str) -> dict:
     }
 
     try:
-        response = requests.post(API_URL, json=payload, headers=headers)
+        response =  requests.post(
+            API_URL,
+            json=payload,
+            headers=headers,
+            timeout=10
+        )
         response.raise_for_status()  # raise error if bad status
         return response.json()
 

--- a/src/tracking/perplexity_client.py
+++ b/src/tracking/perplexity_client.py
@@ -1,0 +1,38 @@
+import os
+import requests
+
+API_URL = "https://api.perplexity.ai/chat/completions"
+
+
+def query_perplexity(prompt: str) -> dict:
+    """Send prompt to Perplexity API and return JSON response."""
+
+    api_key = os.getenv("PERPLEXITY_API_KEY")  # get key from env
+
+    if not api_key:
+        raise ValueError("Missing PERPLEXITY_API_KEY")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    payload = {
+        "model": "sonar-pro",  # model name
+        "messages": [
+            {"role": "user", "content": prompt}
+        ],
+    }
+
+    try:
+        response = requests.post(API_URL, json=payload, headers=headers)
+        response.raise_for_status()  # raise error if bad status
+        return response.json()
+
+    except requests.exceptions.RequestException as e:
+        return {"error": str(e)}  # graceful error
+
+
+if __name__ == "__main__":
+    result = query_perplexity("What brands sell hoodies?")
+    print(result)

--- a/src/tracking/perplexity_client.py
+++ b/src/tracking/perplexity_client.py
@@ -5,7 +5,6 @@ API_URL = "https://api.perplexity.ai/chat/completions"
 
 
 def query_perplexity(prompt: str) -> dict:
-    """Send prompt to Perplexity API and return JSON response."""
 
     api_key = os.getenv("PERPLEXITY_API_KEY")  # get key from env
 

--- a/src/tracking/perplexity_client.py
+++ b/src/tracking/perplexity_client.py
@@ -1,12 +1,14 @@
 import os
+from typing import Dict, Any
 import requests
 
 API_URL = "https://api.perplexity.ai/chat/completions"
 
 
-def query_perplexity(prompt: str) -> dict:
+def query_perplexity(prompt: str) -> Dict[str, Any]:
+    """Send prompt to Perplexity API and return JSON response."""
 
-    api_key = os.getenv("PERPLEXITY_API_KEY")  # get key from env
+    api_key = os.getenv("PERPLEXITY_API_KEY")
 
     if not api_key:
         raise ValueError("Missing PERPLEXITY_API_KEY")
@@ -17,24 +19,24 @@ def query_perplexity(prompt: str) -> dict:
     }
 
     payload = {
-        "model": "sonar-pro",  # model name
+        "model": "sonar-pro",
         "messages": [
             {"role": "user", "content": prompt}
         ],
     }
 
     try:
-        response =  requests.post(
+        response = requests.post(
             API_URL,
             json=payload,
             headers=headers,
-            timeout=10
+            timeout=10,
         )
-        response.raise_for_status()  # raise error if bad status
+        response.raise_for_status()
         return response.json()
 
     except requests.exceptions.RequestException as e:
-        return {"error": str(e)}  # graceful error
+        return {"error": str(e)}
 
 
 if __name__ == "__main__":

--- a/src/tracking/perplexity_client.py
+++ b/src/tracking/perplexity_client.py
@@ -1,5 +1,6 @@
 import os
 from typing import Dict, Any
+
 import requests
 
 API_URL = "https://api.perplexity.ai/chat/completions"
@@ -21,7 +22,7 @@ def query_perplexity(prompt: str) -> Dict[str, Any]:
     payload = {
         "model": "sonar-pro",
         "messages": [
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": prompt},
         ],
     }
 


### PR DESCRIPTION
This PR adds a lightweight Streamlit dashboard to visualize Share of Voice results for the Phase 1 MVP. It uses mock data for now and displays both a table and a simple bar chart to demonstrate how brand visibility can be interpreted visually. I kept the implementation minimal and easy to run locally so it stays clearly separated from the backend pipeline and can be expanded later.